### PR TITLE
Moved to Dockerfile template

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,4 +1,4 @@
-FROM resin/rpi-raspbian:wheezy
+FROM resin/%%RESIN_MACHINE_NAME%%-node:8
 
 COPY raspberrypi.gpg.key /key/
 RUN echo 'deb http://archive.raspberrypi.org/debian/ wheezy main' >> /etc/apt/sources.list.d/raspi.list && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -1,13 +1,4 @@
-FROM resin/%%RESIN_MACHINE_NAME%%-node:8
-
-COPY raspberrypi.gpg.key /key/
-RUN echo 'deb http://archive.raspberrypi.org/debian/ wheezy main' >> /etc/apt/sources.list.d/raspi.list && \
-    echo oracle-java8-jdk shared/accepted-oracle-license-v1-1 select true | /usr/bin/debconf-set-selections && \
-    apt-key add /key/raspberrypi.gpg.key
-
-RUN apt-get update && \
-    apt-get -y install oracle-java8-jdk && \
-    apt-get clean && rm -rf /var/lib/apt/lists/*
+FROM resin/%%RESIN_MACHINE_NAME%%-openjdk:8-jdk
 
 COPY . /usr/src/app
 


### PR DESCRIPTION
I noticed this repo was still using an old raspbian source image (wheezy) that doesn't support systemd yet. I don't know if this is intentional, but I've tested a local push with `FROM resin/raspberrypi3-node:8` and that seemed to work fine, so I think switching to a Docker template file (like resin-electronjs, for example) makes sense. 