### PR TITLE
meta: Adding codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @garethtdavies


### PR DESCRIPTION
Adding a codeowners file. Please feel free to add yourself as I didn't want to add anyone on their behalf 😄 Given this is a very simple repo maybe we can spread the codeowners around so the same people are not always being pinged.

Change-type: patch
Signed-off-by: Gareth Davies <gareth@balena.io>